### PR TITLE
adjust bc_num_gpus.to_i variable

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -12,7 +12,7 @@ script:
     <%- end -%>
     - "-t"
     - "0-<%= bc_num_hours %>"
-    <%- unless bc_num_gpus.blank? or bc_num_gpus.to_i == 0 -%>
+    <%- unless bc_num_gpus.blank? or bc_num_gpus == 0 -%>
     - "--gres=gpu:<%= bc_num_gpus %>"
     <%- end -%>
     <%- unless bc_reservation.blank? -%>


### PR DESCRIPTION
I'm not exactly sure how this ruby template works, but I did notice a discrepancy in the check in line 15 with the assignment in line 16.

I did try changing line 16 to match the conditional in 15 (bc_num_gpus.to_i) but that did not work.

The current change also brings this in line with the working JupyterLab app (bc_num_gpus)


Tested on mgportal2
`[root@mgsched1 ~]# scontrol show job 16708917`
`   TresPerNode=gres/gpu:nvidia_a100-sxm4-40gb:1`